### PR TITLE
fix: fix wrong advice order

### DIFF
--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -19,7 +19,7 @@ function wrapMethod (target, methodName, beforeKey, afterKey, caller?) {
 function applyReflect (target, advices, methodName, keyJoinPoint, original) {
   const keyOriginalMethod = generateKey(KEY_ORIGINAL_METHOD, methodName)
   const adviceArr = Reflect.getMetadata(keyJoinPoint, target) || []
-  adviceArr.push(...advices.map(reflect.advice))
+  adviceArr.unshift(...advices.map(reflect.advice))
   Reflect.defineMetadata(keyJoinPoint, adviceArr, target)
   if (!Reflect.getMetadata(keyOriginalMethod, target)) Reflect.defineMetadata(keyOriginalMethod, original, target)
 

--- a/test/decorator-order.spec.ts
+++ b/test/decorator-order.spec.ts
@@ -1,10 +1,10 @@
 import { beforeMethod, afterMethod, afterInstance, beforeInstance } from "../src"
 
 const op1 = meta => meta.args[0]++
-const op2 = meta => meta.args[0] * 2
-const op3 = meta => meta.args[0] - 5
-const op4 = meta => meta.args[0] * 10
-const op5 = meta => meta.args[0] / 2
+const op2 = meta => meta.args[0] *= 2
+const op3 = meta => meta.args[0] -= 5
+const op4 = meta => meta.args[0] *= 10
+const op5 = meta => meta.args[0] /= 2
 
 @beforeInstance(op2)
 @beforeInstance(op1)


### PR DESCRIPTION
BREAKING CHANGE: stacked joinpoints will be executed from top to bottom, see iss-116

fix #116